### PR TITLE
Fix several issues with error logging:

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,15 +17,14 @@ var consoleWrapper = function (func, identifyCaller) {
 var consoleErrorWrapper = function () {
     var orig = console.error;
     return function () {
-        var err = Array.prototype.slice.call(arguments);
+        var args = Array.prototype.slice.call(arguments);
+        var err = args[0]
         var caller = getOriginalCaller(err);
         var values = [
             new Date().toISOString(),
             'ERROR',
-            caller,
-            err,
-            err.stack
-        ];
+            caller
+        ].concat(args, err.stack || '')
         orig.apply(console, values);
     };
 }
@@ -43,7 +42,7 @@ function getOriginalCaller (error) {
     // Index 2 - The console wrapper function
     // Index 3 - Original calling function
     var stackIndex = 1;
-    if (error === undefined) {
+    if (!error || !error.stack) {
         stack = new Error().stack;
         stackIndex = 3;
     } else {
@@ -65,7 +64,7 @@ function override (identifyCaller) {
     console.log = consoleWrapper('log', identifyCaller);
     console.info = consoleWrapper('info', identifyCaller);
     console.warn = consoleWrapper('warn', identifyCaller);
-    console.error = consoleErrorWrapper;
+    console.error = consoleErrorWrapper();
 }
 
 module.exports.override = function (identifyCaller) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "uniform-logs",
-    "version": "0.0.1",
+    "version": "0.0.2",
     "description": "Override the default console methods to enforce a single log format",
     "main": "index.js",
     "repository": {


### PR DESCRIPTION
1. The console error wrapper swallowed errors because it was used as-is, instead of invoked to return the error logger function
2. Some errors/arguments doesn't contain the stack, in which case the stack.split() will fail
3. The function expected a single err argument, while some error logs contains multiple arguments
4. Also - the arguments were used as an array, instead of extracting the first err argument

@liorrozen - this library contains no tests. if approved, please merge and publish to npm (version already bumped to 0.0.2)
